### PR TITLE
[FE:FIX] DefaultText Button console 오류 해결

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1052,9 +1052,9 @@
       }
     },
     "node_modules/@mantine/hooks": {
-      "version": "7.9.2",
-      "resolved": "https://registry.npmjs.org/@mantine/hooks/-/hooks-7.9.2.tgz",
-      "integrity": "sha512-qT8vvHZ8K/qFXSSIyq/NHpKgtEs1Vas4Z2tPPtMTN7oyibjsel09XebPAt59nkJS/SACQbja0GZ4lUXI2+AFFw==",
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/@mantine/hooks/-/hooks-7.10.0.tgz",
+      "integrity": "sha512-fnalwYS2WQEFS4wmhmAetDZ/VdJPLNeUXPX9t+S21o3p/dRTX1xhU2mS7yWaQUKM0hPD1TcujqXGlP2M2g/A9A==",
       "peerDependencies": {
         "react": "^18.2.0"
       }

--- a/client/src/Component/Common/Button/DefaultText.tsx
+++ b/client/src/Component/Common/Button/DefaultText.tsx
@@ -52,7 +52,6 @@ const DefaultText: React.FC<DefaultTextProps> = ({
       }}
     >
       <TextStyles
-        isHovered={isHovered}
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
       >
@@ -66,14 +65,12 @@ const DefaultText: React.FC<DefaultTextProps> = ({
         {leftText}
       </TextStyles>
       <TextStyles
-        isHovered={isHovered}
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
       >
         {centerText}
       </TextStyles>
       <TextStyles
-        isHovered={isHovered}
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
       >

--- a/client/src/Component/Common/Button/TextStyles.ts
+++ b/client/src/Component/Common/Button/TextStyles.ts
@@ -1,20 +1,19 @@
 import styled from "styled-components";
 
-interface StyledTextProps {
-  isHovered: boolean;
-}
-
-export const TextStyles = styled.span<StyledTextProps>`
+export const TextStyles = styled.span`
   display: flex;
   align-items: center;
   gap: 4px;
-  font-weight: ${(props) => (props.isHovered ? 500 : 400)};
-  color: ${(props) => (props.isHovered ? "#FF7000" : "inherit")};
   cursor: pointer;
 
   & img {
     width: 16px;
     height: 16px;
     padding-bottom: 3px;
+  }
+
+  &:hover {
+    font-weight: 500;
+    color: #ff7000;
   }
 `;


### PR DESCRIPTION
<!---- 주석은 삭제 안하셔도 됩니다~ ---->
### 🔍 Overview
<!---- 작업한 페이지, 컴포넌트, 기능 등의 변경/추가 사항을 한두줄로 써주세요. --->
DefaultText Button 사용 시 isHovered state로 인하여 Mantine/Hooks 와 충돌이 일어나 console error가 뜸.
**해결**
TextStyle에 있는 isHovered props 삭제 및 styled-component로 :hover 추가