### PR TITLE
[FE:Feat] 선생님 선호도 조사 Modal 기능 구현

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,12 +1,14 @@
-import { BrowserRouter } from "react-router-dom";
+import { BrowserRouter, Routes, Route } from "react-router-dom";
 import "@mantine/core/styles.css";
+
+import Index from "./Pages/Index/Index";
 
 function App() {
   return (
     <BrowserRouter>
-      <div>
-        얘는 냅두고 아래에 Component 연결 후 url 넣기 이친구는 나중에 같이 삭제
-      </div>
+      <Routes>
+        <Route path="/" element={<Index />} />
+      </Routes>
     </BrowserRouter>
   );
 }

--- a/client/src/Component/Common/Button/OutlineButton.styles.ts
+++ b/client/src/Component/Common/Button/OutlineButton.styles.ts
@@ -4,33 +4,32 @@ export const StyledButtonWrapper = styled.div`
   display: block;
 `;
 
-export const getButtonStyles = (
-  variant: string,
-  hovered: boolean,
-  borderColor: string
+export const getCommonButtonStyles = (
+  borderColor: string,
+  disabled: boolean,
+  hovered: boolean
 ) => {
+  return {
+    width: "100%",
+    border: `1px solid ${disabled ? "#999999" : borderColor}`,
+    backgroundColor: disabled ? "#b2b2b2" : hovered ? "#FFD8B8" : "#ffffff",
+    transition: "0.2s",
+    color: hovered ? "#FF7000" : "#FF7000",
+  };
+};
+export const getButtonStyles = (variant: string) => {
   switch (variant) {
     case "outline":
       return {
-        width: "100%",
         height: "56px",
         fontSize: "16px",
         fontWeight: "700",
-        border: `1px solid ${borderColor}`,
-        color: hovered ? "#FF7000" : "#FF7000",
-        backgroundColor: hovered ? "#FFD8B8" : "#ffffff",
-        transition: "0.2s",
       };
     case "m_outline":
       return {
-        width: "100%",
         height: "32px",
         fontSize: "14px",
         fontWeight: "500",
-        border: `1px solid ${borderColor}`,
-        color: hovered ? "#FF7000" : "#FF7000",
-        backgroundColor: hovered ? "#FFD8B8" : "#ffffff",
-        transition: "0.2s",
       };
     default:
       return {};

--- a/client/src/Component/Common/Button/OutlineButton.tsx
+++ b/client/src/Component/Common/Button/OutlineButton.tsx
@@ -1,13 +1,18 @@
 import { Button } from "@mantine/core";
 import "@mantine/core/styles.css";
 import { useHover } from "@mantine/hooks";
-import { StyledButtonWrapper, getButtonStyles } from "./OutlineButton.styles";
+import {
+  StyledButtonWrapper,
+  getButtonStyles,
+  getCommonButtonStyles,
+} from "./OutlineButton.styles";
 
 interface OutlineButtonProps {
   variant?: "outline" | "m_outline";
   text?: string; // text 속성 추가
-  onClick?: () => void;
+  onClick?(event: React.MouseEvent<HTMLButtonElement>): void;
   borderColor?: string;
+  disabled?: boolean;
 }
 
 function OutlineButton({
@@ -15,6 +20,7 @@ function OutlineButton({
   text = "",
   onClick,
   borderColor = "#FF7000",
+  disabled = false,
 }: OutlineButtonProps) {
   const { hovered, ref } = useHover();
 
@@ -23,7 +29,8 @@ function OutlineButton({
       <Button
         style={{
           display: "flex",
-          ...getButtonStyles(variant, hovered, borderColor),
+          ...getButtonStyles(variant),
+          ...getCommonButtonStyles(borderColor, disabled, hovered),
         }}
         variant={
           variant === "outline"
@@ -34,8 +41,8 @@ function OutlineButton({
         }
         color="#FF7000"
         radius={variant === "outline" ? "16px" : "8px"}
-        className=""
         onClick={onClick}
+        disabled={disabled}
       >
         {text}
       </Button>

--- a/client/src/Component/Common/Chatbox/ChatboxSystem.tsx
+++ b/client/src/Component/Common/Chatbox/ChatboxSystem.tsx
@@ -8,18 +8,22 @@ import {
 } from "./Chatbox.style";
 import LoadingAnimation from "../../../Assets/Animation/Loading.gif";
 
-type ChatboxSystemProps = {
+interface ChatboxSystemProps {
   highlightWords?: string;
   messages?: string;
   button?: string[];
   animation?: boolean;
-};
+  onClick?(event: React.MouseEvent<HTMLButtonElement>): void;
+  disabled?: boolean;
+}
 
 function ChatboxSystem({
   highlightWords = "",
   messages = "",
   button = [],
   animation = false,
+  onClick,
+  disabled = false,
 }: ChatboxSystemProps) {
   return (
     <StyledChatboxSystemBox>
@@ -35,6 +39,7 @@ function ChatboxSystem({
       {button ? (
         <StyledButtonWrapper
           className={messages.includes("선생님 성별") ? "gender_buttons" : ""}
+          style={{ color: disabled ? "#999999" : "#333333" }}
         >
           {button.map((text) => {
             return (
@@ -43,6 +48,8 @@ function ChatboxSystem({
                 text={text}
                 variant="m_outline"
                 borderColor="#c1c1c1"
+                onClick={onClick}
+                disabled={disabled}
               ></OutlineButton>
             );
           })}

--- a/client/src/Component/Common/Modal/Modal.tsx
+++ b/client/src/Component/Common/Modal/Modal.tsx
@@ -12,14 +12,6 @@ import {
 import IconRemove from "../../../Assets/Image/Icon/IconRemove.svg";
 import ChatProfile from "../../../Assets/Image/ChatProfile.svg";
 
-type ModalProps = {
-  content: () => JSX.Element;
-  buttonText: string;
-  chatInput?: boolean;
-  buttonVariant?: "filled" | "outlined";
-  buttonIcon?: "search" | undefined; //필요 시 버튼 아이콘 추가
-};
-
 function Modal({
   content,
   buttonText,
@@ -83,5 +75,13 @@ function Modal({
     </>
   );
 }
+
+type ModalProps = {
+  content: () => JSX.Element;
+  buttonText: string;
+  chatInput?: boolean;
+  buttonVariant?: "filled" | "outlined";
+  buttonIcon?: "search" | undefined; //필요 시 버튼 아이콘 추가
+};
 
 export default Modal;

--- a/client/src/Component/Common/Modal/ModalContent/TherapistPreference.tsx
+++ b/client/src/Component/Common/Modal/ModalContent/TherapistPreference.tsx
@@ -1,38 +1,140 @@
+import { useState, useEffect, useCallback } from "react";
+import { useDispatch } from "react-redux";
+
 import ChatboxSystem from "../../Chatbox/ChatboxSystem";
 import ChatboxUser from "../../Chatbox/ChatboxUser";
+
+import { useDelayChatbox } from "../../../../Services/CustomHooks";
+import { matchingSurveyActions } from "../../../../Store/Slices/MatchingSurveySlice";
 
 import surveyText from "../../../../Assets/TextData/surveyText";
 import { PreferenceTextType } from "./ModalContentType";
 
 function TherapistPreference() {
-  const textData: object | undefined = surveyText.find(
+  const textData: PreferenceTextType | undefined = surveyText.find(
     (data) => data.type === "preference"
-  );
-  const { messages, selectGender, selectCareer } =
-    textData as PreferenceTextType;
+  ) as PreferenceTextType;
 
-  return (
-    <section>
-      <ChatboxSystem messages={messages.intro} highlightWords="선생님 매칭" />
+  const { messages, selectGender, selectCareer } = textData;
+
+  const [conversation, setConversation] = useState<JSX.Element[]>([]);
+  const [currentStep, setCurrentStep] = useState<number>(0);
+  const [isGenderButtonDisabled, setIsGenderButtonDisabled] =
+    useState<boolean>(false);
+  const [isCareerButtonDisabled, setIsCareerButtonDisabled] =
+    useState<boolean>(false);
+
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    const initialConversation = [
       <ChatboxSystem
-        messages={messages.gender}
-        highlightWords="선생님 성별"
-        button={selectGender}
-      />
-      <ChatboxUser messages="네" highlightWords="네" />
-      <ChatboxSystem
-        messages={messages.career}
-        highlightWords="경력"
-        button={selectCareer}
-      />
-      <ChatboxUser messages="네" highlightWords="네" />
-      <ChatboxSystem
-        messages={messages.loading}
-        highlightWords={messages.loading}
-        animation={true}
-      />
-    </section>
+        key="intro"
+        messages={messages.intro}
+        highlightWords="선생님 매칭"
+      />,
+    ];
+    setConversation(initialConversation);
+    setCurrentStep(1); // Start with step 1 after the initial intro message
+  }, [messages.intro]);
+
+  useEffect(() => {
+    const addConversationStep = async () => {
+      if (currentStep === 1) {
+        await useDelayChatbox(1000);
+        setConversation((prev) => [
+          ...prev,
+          <ChatboxSystem
+            key="selectGender"
+            messages={messages.gender}
+            highlightWords="선생님 성별"
+            button={selectGender}
+            onClick={getGenderPreferenceAnswer}
+            disabled={isGenderButtonDisabled}
+          />,
+        ]);
+      } else if (currentStep === 2) {
+        await useDelayChatbox(500);
+        setConversation((prev) => [
+          ...prev,
+          <ChatboxSystem
+            key="selectCareer"
+            messages={messages.career}
+            highlightWords="경력"
+            button={selectCareer}
+            onClick={getCareerPreferenceAnswer}
+            disabled={isCareerButtonDisabled}
+          />,
+        ]);
+      } else if (currentStep === 3) {
+        await useDelayChatbox(500);
+        setConversation((prev) => [
+          ...prev,
+          <ChatboxSystem
+            key="loading"
+            messages={messages.loading}
+            highlightWords={messages.loading}
+            animation={true}
+          />,
+        ]);
+      }
+    };
+
+    addConversationStep();
+  }, [
+    currentStep,
+    messages.gender,
+    messages.career,
+    messages.loading,
+    selectGender,
+    selectCareer,
+    isGenderButtonDisabled,
+    isCareerButtonDisabled,
+  ]);
+
+  const getGenderPreferenceAnswer = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      event.preventDefault();
+      let answer = event.currentTarget.textContent as string;
+      if (answer === "상관 없어요!") {
+        return (answer = "전체");
+      }
+      dispatch(matchingSurveyActions.setGenderPreference(answer));
+      setIsGenderButtonDisabled(true);
+      setConversation((prev) => [
+        ...prev,
+        <ChatboxUser
+          key="gender-answer"
+          messages={answer}
+          highlightWords={answer}
+        />,
+      ]);
+      setCurrentStep(2); // Move to the next step
+    },
+    []
   );
+
+  const getCareerPreferenceAnswer = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      event.preventDefault();
+      const answer = event.currentTarget.textContent as string;
+      const answerToBoolean: boolean = answer === "네" ? true : false;
+      dispatch(matchingSurveyActions.setCareerPreference(answerToBoolean));
+      setIsCareerButtonDisabled(true);
+      setConversation((prev) => [
+        ...prev,
+        <ChatboxUser
+          key="career-answer"
+          messages={answer}
+          highlightWords={answer}
+        />,
+      ]);
+      setCurrentStep(3);
+    },
+    []
+  );
+
+  return <section>{conversation}</section>;
 }
 
 export default TherapistPreference;

--- a/client/src/Pages/Index/Index.tsx
+++ b/client/src/Pages/Index/Index.tsx
@@ -2,7 +2,7 @@ import Footer from "../../Component/Common/Footer/Footer";
 import Header from "../../Component/Common/Header/Header";
 
 import Modal from "../../Component/Common/Modal/Modal";
-import SurveyModalContent from "../../Component/Common/Modal/ModalContent/SurveyModalContent";
+import TherapistPreference from "../../Component/Common/Modal/ModalContent/TherapistPreference";
 import TherapistCard from "../../Component/Common/Card/TherapistCard/TherapistCard";
 
 import externalRecommendSites from "../../Assets/TextData/externalRecommendSites";
@@ -31,7 +31,7 @@ function Index() {
             </div>
             <Modal
               buttonText="선생님 찾아보기"
-              content={SurveyModalContent}
+              content={TherapistPreference}
               buttonIcon="search"
             />
           </div>

--- a/client/src/Services/CustomHooks.tsx
+++ b/client/src/Services/CustomHooks.tsx
@@ -28,3 +28,8 @@ export function useGetChildAge(dateOfBirth: string) {
   }
   return age;
 }
+
+// chatbox 시간 지연 커스텀 훅
+export function useDelayChatbox(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/client/src/Store/Slices/MatchingSurveySlice.tsx
+++ b/client/src/Store/Slices/MatchingSurveySlice.tsx
@@ -1,0 +1,44 @@
+import { createSlice } from "@reduxjs/toolkit";
+import type { PayloadAction } from "@reduxjs/toolkit";
+
+export interface PreferenceSurveyState {
+  treatmentArea: string[];
+  preference: {
+    gender: string | undefined;
+    career: boolean;
+  };
+}
+
+const initialState: PreferenceSurveyState = {
+  treatmentArea: [],
+  preference: {
+    gender: "",
+    career: false,
+  },
+};
+
+const matchingSurveySlice = createSlice({
+  name: "preferenceData",
+  initialState,
+  reducers: {
+    setTreatmentAreaPreference: (
+      state,
+      action: PayloadAction<treatmentAreaType>
+    ) => {
+      state.treatmentArea = action.payload;
+    },
+    setGenderPreference: (state, action: PayloadAction<genderType>) => {
+      state.preference.gender = action.payload;
+    },
+    setCareerPreference: (state, action: PayloadAction<careerType>) => {
+      state.preference.career = action.payload;
+    },
+  },
+});
+
+export default matchingSurveySlice.reducer;
+export const matchingSurveyActions = matchingSurveySlice.actions;
+
+type genderType = string;
+type careerType = boolean;
+type treatmentAreaType = string[];

--- a/client/src/Store/store.ts
+++ b/client/src/Store/store.ts
@@ -1,11 +1,11 @@
 import { configureStore } from "@reduxjs/toolkit";
+import matchingSurveySlice from "./Slices/MatchingSurveySlice";
 
 export const store = configureStore({
   reducer: {
-    // slice 입력하기
+    preferenceData: matchingSurveySlice,
   },
 });
 
 export type RootState = ReturnType<typeof store.getState>;
-
 export type AppDispatch = typeof store.dispatch;


### PR DESCRIPTION
<!---- 주석은 삭제 안하셔도 됩니다~ ---->
### 🔍 Overview
<!---- 작업한 페이지, 컴포넌트, 기능 등의 변경/추가 사항을 한두줄로 써주세요. --->
선생님 선호도 조사 Modal 기능 구현 및 선호도 데이터 rtk로 상태관리 slicer 추가

### ✅ Summary
<!---- 간단요약하게 bullet 형태로 요약해주세요 ---->
- 선호도 조사 Modal 기능 구현 
- 선호도 조사 데이터 저장 시 RTK로 상태 관리
- Outline Button OnClick Props 변경 및 disabled 상태 props, css 추가
- App화면 Routes, Route 추가

### 🖌️ Description
<!--- 상세한 설명을 넣어주세요 ---->
**선호도 조사 Modal 기능 구현**
- 답변 선택 시 시간 차로 답변과 질문이 나오는 기능

**MatchingSurveySlicer 상태 관리 RTK 추가**
- 검색 시 저장이 필요한 선호도 데이터들을 저장하는 기능 => 추후 검색 페이지에서 이용

### 🖼️ Screenshot
<!---- 작업한 해당 화면이 있으면 스크린샷을 올려주세요 ---->
<!---- 화면 작업이 아닐 경우 이 전체 섹션을 삭제해주세요 ---->
![20240603_140502](https://github.com/kidsConnection/kidsconnect/assets/124794790/fb87f408-8eed-431f-bc4d-c7041d167e0d)
<img width="453" alt="스크린샷 2024-06-03 오후 4 14 09" src="https://github.com/kidsConnection/kidsconnect/assets/124794790/d49157f3-ed5e-4e77-a35d-6f27d38e838c">
